### PR TITLE
[Fix] 로그인 시 refreshToken 저장 및 만료 시 재발급

### DIFF
--- a/src/api/instance/backend.jsx
+++ b/src/api/instance/backend.jsx
@@ -22,11 +22,10 @@ instance.interceptors.response.use(
     return response; // 성공적으로 응답 받은 경우 그대로 반환
   },
   async (error) => {
-    // 401: Unauthorized (토큰 만료 또는 잘못된 토큰)
-    if (error.response && error.response.status === 401) {
+    // 403: Unauthorized (토큰 만료 또는 잘못된 토큰)
+    if (error.response && error.response.status === 403) {
       const originalRequest = error.config;
 
-      // 이미 리프레시 토큰을 이용한 요청을 하고 있다면 무한 루프 방지
       if (originalRequest._retry) {
         return Promise.reject(error);
       }
@@ -36,17 +35,17 @@ instance.interceptors.response.use(
       // refreshToken을 이용해 새로운 accessToken을 발급받는다
       try {
         const refreshToken = localStorage.getItem('refreshToken');
-        const response = await axios.post(`${import.meta.env.VITE_BACKEND_BASE_URL}/token/refresh`, {
-          jwt: refreshToken,
+        const response = await axios.post(`${import.meta.env.VITE_BACKEND_BASE_URL}/auth/token/refresh`, {
+          refreshToken: refreshToken,
         });
 
-        const newAccessToken = response.data.accessToken;
+        const newAccessToken = response.data.data.jwt;
 
         // 새로운 accessToken을 로컬 스토리지에 저장
         localStorage.setItem('accessToken', newAccessToken);
 
         // 원래 요청의 Authorization 헤더에 새로운 accessToken을 추가
-        originalRequest.headers['Authorization'] = 'Bearer ' + newAccessToken;
+        originalRequest.headers.Authorization = 'Bearer ' + newAccessToken;
 
         // 원래 요청을 다시 시도
         return axios(originalRequest);
@@ -55,7 +54,7 @@ instance.interceptors.response.use(
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         // 예를 들어 로그인 페이지로 리다이렉트하거나 사용자에게 로그아웃 알림을 보여줄 수 있음
-        window.location.href = '/login';
+        window.location.href = '/auth';
         return Promise.reject(refreshError);
       }
     }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -45,6 +45,7 @@ export default function Login() {
           // 로그인 성공 시 accessToken을 localStorage에 저장
           const accessToken = data.jwt;
           localStorage.setItem("accessToken", accessToken);
+          localStorage.setItem("refreshToken", data.refreshToken);
           localStorage.setItem("userId", data.user.userId);
 
           const hasCompletedSurvey = data.user.hasCompletedSurvey;


### PR DESCRIPTION
## 작업한 내용
- 로그인 시 refreshToken 저장 및 만료 시 재발급


## PR POINT
- 기존에 엔드포인트와 저장 문제로 버그 발생


## 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "" width ="250">|

## 관련 이슈
- Resolved: #27 
